### PR TITLE
bottleneck 1.3.4

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,2 +1,0 @@
-numpy:      # [aarch64]
-  - '1.16'  # [aarch64]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "1.3.2" %}
+{% set version = "1.3.4" %}
 
 package:
   name: bottleneck
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/B/Bottleneck/Bottleneck-{{ version }}.tar.gz
-  sha256: 20179f0b66359792ea283b69aa16366419132f3b6cf3adadc0c48e2e8118e573
+  sha256: 1764a7f4ad58c558723c542847eb367ab0bbb6d880a4e5d5eef30a0ece5cecea
 
 build:
   number: 1

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,15 +1,16 @@
+{% set name = "bottleneck" %}
 {% set version = "1.3.4" %}
 
 package:
-  name: bottleneck
+  name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/B/Bottleneck/Bottleneck-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/Bottleneck-{{ version }}.tar.gz
   sha256: 1764a7f4ad58c558723c542847eb367ab0bbb6d880a4e5d5eef30a0ece5cecea
 
 build:
-  number: 1
+  number: 0
   script: {{ PYTHON }} -m pip install . -vv
 
 requirements:
@@ -19,12 +20,15 @@ requirements:
     - python
     - pip
     - numpy
+    - setuptools
+    - wheel
   run:
     - python
     - {{ pin_compatible('numpy') }}
 
 test:
   requires:
+    - pip
     - pytest
   imports:
     - bottleneck
@@ -35,6 +39,7 @@ test:
     - bottleneck.nonreduce_axis
     - bottleneck.move
   commands:
+    - pip check
     - python -c "import bottleneck; bottleneck.test()"
 
 about:


### PR DESCRIPTION
Update bottleneck to 1.3.4

Bug Tracker: new open issues https://github.com/pydata/bottleneck/issues
Upstream license:  License file:  https://github.com/pydata/bottleneck/blob/master/LICENSE
Installing: https://github.com/pydata/bottleneck/blob/master/doc/source/installing.rst
Upstream setup.py:  https://github.com/pydata/bottleneck/blob/v1.3.4/setup.py
Upstream pyproject.toml:  https://github.com/pydata/bottleneck/blob/v1.3.4/pyproject.toml

The package bottleneck is mentioned inside the packages:
bottlechest | glue-core | orange3 | pandas |


Actions:
1. Reset build number to 0
2. Add missing host dependencies: setuptools, wheel
3. Add pip check

Result:
- all-succeeded
