### PR TITLE
bottleneck 1.3.5

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "bottleneck" %}
-{% set version = "1.3.4" %}
+{% set version = "1.3.5" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/Bottleneck-{{ version }}.tar.gz
-  sha256: 1764a7f4ad58c558723c542847eb367ab0bbb6d880a4e5d5eef30a0ece5cecea
+  sha256: 2c0d27afe45351f6f421893362621804fa7dea14fe29a78eaa52d4323f646de7
 
 build:
   number: 0


### PR DESCRIPTION
Update bottleneck to 1.3.5

Bug Tracker: new open issues https://github.com/pydata/bottleneck/issues
Upstream license: License file: https://github.com/pydata/bottleneck/blob/master/LICENSE
Installing: https://github.com/pydata/bottleneck/blob/master/doc/source/installing.rst
Upstream setup.py: https://github.com/pydata/bottleneck/blob/v1.3.5/setup.py
Upstream pyproject.toml: https://github.com/pydata/bottleneck/blob/v1.3.5/pyproject.toml

The package bottleneck is mentioned inside the packages:
bottlechest | glue-core | orange3 | pandas |

No actions