### PR TITLE
Version 1.3.7

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
 
 build:
   number: 0
-  script: {{ PYTHON }} -m pip install . -vv
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
 
 requirements:
   build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,7 +19,7 @@ requirements:
   host:
     - python
     - pip
-    - numpy
+    - numpy {{ numpy }}
     - setuptools
     - wheel
     - versioneer

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -22,6 +22,7 @@ requirements:
     - numpy
     - setuptools
     - wheel
+    - versioneer
   run:
     - python
     - {{ pin_compatible('numpy') }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "bottleneck" %}
-{% set version = "1.3.5" %}
+{% set version = "1.3.7" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/Bottleneck-{{ version }}.tar.gz
-  sha256: 2c0d27afe45351f6f421893362621804fa7dea14fe29a78eaa52d4323f646de7
+  sha256: e1467e373ad469da340ed0ff283214d6531cc08bfdca2083361a3aa6470681f8
 
 build:
   number: 0


### PR DESCRIPTION
bottleneck 1.3.7

**Destination channel:** defaults

### Links

- [Upstream repository](https://github.com/pydata/bottleneck/tree/v1.3.7)
- [Upstream changelog/diff](https://github.com/pydata/bottleneck/blob/v1.3.7/RELEASE.rst)
- Relevant dependency PRs:
  - https://github.com/pandas-dev/pandas/tree/v2.2.0

### Explanation of changes:

- Update to 1.3.7
- Update dependencies and build script
