### PR TITLE
Version 1.4.2

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+build_env_vars:
+  ANACONDA_ROCKET_ENABLE_PY313 : yes

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -26,7 +26,7 @@ requirements:
     - versioneer
   run:
     - python
-    - numpy >=2.0.0
+    - numpy
 
 test:
   requires:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -63,3 +63,6 @@ extra:
     - wesm
     - ocefpaf
     - qwhelan
+  skip-lints:
+    - invalid_url
+    - host_section_needs_exact_pinnings

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,15 +1,16 @@
 {% set name = "bottleneck" %}
-{% set version = "1.3.7" %}
+{% set version = "1.4.2" %}
 
 package:
   name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/Bottleneck-{{ version }}.tar.gz
-  sha256: e1467e373ad469da340ed0ff283214d6531cc08bfdca2083361a3aa6470681f8
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/bottleneck-{{ version }}.tar.gz
+  sha256: fa8e8e1799dea5483ce6669462660f9d9a95649f6f98a80d315b84ec89f449f4
 
 build:
+  skip: True  # [py<39]
   number: 0  # trigger
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
 
@@ -19,13 +20,13 @@ requirements:
   host:
     - python
     - pip
-    - numpy {{ numpy }}
+    - numpy >=2.0.0
     - setuptools
     - wheel
     - versioneer
   run:
     - python
-    - {{ pin_compatible('numpy') }}
+    - numpy >=2.0.0
 
 test:
   requires:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -20,7 +20,7 @@ requirements:
   host:
     - python
     - pip
-    - numpy >=2.0.0
+    - numpy >=2.0.0,<2.3.0
     - setuptools
     - wheel
     - versioneer

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
 
 build:
   skip: True  # [py<39]
-  number: 0  # trigger
+  number: 0
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
 
 requirements:


### PR DESCRIPTION
Bottleneck 1.4.2
**Destination channel:** defaults

### Links

- [PKG-5963](https://anaconda.atlassian.net/browse/PKG-5963) 
- [Upstream repository](https://github.com/pydata/bottleneck)
- [Upstream changelog/diff](https://github.com/pydata/bottleneck)
- Relevant dependency PRs:
  - ...

### Explanation of changes:
- change numpy version and update sha and version 


[PKG-5963]: https://anaconda.atlassian.net/browse/PKG-5963?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ