### PR TITLE
Update bottleneck 1.4.2 -> 1.6.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -64,5 +64,4 @@ extra:
     - ocefpaf
     - qwhelan
   skip-lints:
-    - invalid_url
     - host_section_needs_exact_pinnings

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "bottleneck" %}
-{% set version = "1.4.2" %}
+{% set version = "1.6.0" %}
 
 package:
   name: {{ name|lower }}
@@ -7,11 +7,11 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/bottleneck-{{ version }}.tar.gz
-  sha256: fa8e8e1799dea5483ce6669462660f9d9a95649f6f98a80d315b84ec89f449f4
+  sha256: 028d46ee4b025ad9ab4d79924113816f825f62b17b87c9e1d0d8ce144a4a0e31
 
 build:
-  skip: True  # [py<39]
-  number: 1
+  skip: True  # [py<310]
+  number: 0
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
 
 requirements:
@@ -21,9 +21,8 @@ requirements:
   host:
     - python
     - pip
-    - numpy {{ numpy }}
+    - numpy
     - setuptools
-    - wheel
     - versioneer
   run:
     - python


### PR DESCRIPTION
## Links
- [PyPI](https://pypi.org/project/bottleneck/1.6.0)
- [PyPI Inspector](https://inspector.pypi.io/project/bottleneck/1.6.0)
- [PKG-15511](https://anaconda.atlassian.net/browse/PKG-15511)

## Changes
- Update bottleneck 1.4.2 → 1.6.0
- Update sha256
- Update skip to py<310 (requires_python >= 3.10)
- Drop `numpy {{ numpy }}` ABI pinning in host (numpy 2.x ABI model)
- Remove `wheel` from host (not required by setuptools.build_meta)
- Reset build number to 0

## Notes
- No vulnerabilities found (Snyk, PyPI)
- BSD-2-Clause license (approved)

[PKG-15511]: https://anaconda.atlassian.net/browse/PKG-15511?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ